### PR TITLE
Fix various bugs on program shutdown and races

### DIFF
--- a/cmd/photobak/main.go
+++ b/cmd/photobak/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -47,7 +48,7 @@ type daemon struct {
 
 func startDaemon(interval time.Duration) {
 	d := daemon{signalChan: make(chan os.Signal, 1)}
-	signal.Notify(d.signalChan, os.Interrupt)
+	signal.Notify(d.signalChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
 		<-d.signalChan

--- a/cmd/photobak/main.go
+++ b/cmd/photobak/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
 	"time"
 
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -36,6 +37,76 @@ func init() {
 	flag.BoolVar(&prune, "prune", prune, "Clean up removed photos and albums")
 	flag.BoolVar(&authOnly, "authonly", authOnly, "Obtain authorizations only; do not perform backups")
 	flag.BoolVar(&verbose, "v", verbose, "Write informational log messages to stdout")
+}
+
+type daemon struct {
+	repo       *photobak.Repository
+	repoLock   sync.Mutex
+	signalChan chan os.Signal
+}
+
+func startDaemon(interval time.Duration) {
+	d := daemon{signalChan: make(chan os.Signal, 1)}
+	signal.Notify(d.signalChan, os.Interrupt)
+
+	go func() {
+		<-d.signalChan
+		log.Println("[INTERRUPT] Closing database and quitting")
+		d.close(true)
+	}()
+
+	if err := d.run(); err != nil {
+		if interval == 0 {
+			log.Fatal(err)
+		} else {
+			log.Println(err)
+		}
+	}
+
+	if interval == 0 {
+		return
+	}
+
+	for range time.Tick(interval) {
+		log.Println("Running backup")
+		if err := d.run(); err != nil {
+			log.Println(err)
+		}
+	}
+}
+
+func (d *daemon) run() error {
+	repo, err := photobak.OpenRepo(repoDir)
+	if err != nil {
+		return fmt.Errorf("opening repo: %v", err)
+	}
+
+	d.repoLock.Lock()
+	d.repo = repo
+	d.repoLock.Unlock()
+	defer d.close(false)
+
+	repo.NumWorkers = concurrency
+
+	if prune {
+		return repo.Prune()
+	}
+
+	return repo.Store(keepEverything)
+}
+
+func (d *daemon) close(exit bool) {
+	d.repoLock.Lock()
+	defer d.repoLock.Unlock()
+
+	if d.repo != nil {
+		d.repo.Close()
+		d.repo = nil
+	}
+
+	if exit {
+		os.Exit(0)
+	}
 }
 
 func main() {
@@ -85,21 +156,7 @@ func main() {
 		}
 	}
 
-	err := run()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if every != "" {
-		c := time.Tick(itvl)
-		for range c {
-			log.Println("Running backup")
-			err := run()
-			if err != nil {
-				log.Println(err)
-			}
-		}
-	}
+	startDaemon(itvl)
 }
 
 func parseEvery(every string) (time.Duration, error) {
@@ -129,39 +186,6 @@ func parseEvery(every string) (time.Duration, error) {
 	}
 
 	return time.Duration(minutes) * time.Minute, nil
-}
-
-func run() error {
-	waitchan := make(chan struct{})
-
-	repo, err := photobak.OpenRepo(repoDir)
-	if err != nil {
-		return fmt.Errorf("opening repo: %v", err)
-	}
-	defer close(waitchan)
-
-	// cleanly close repository when interrupted
-	// or when the function ends
-	go func() {
-		sigchan := make(chan os.Signal, 1)
-		signal.Notify(sigchan, os.Interrupt)
-		select {
-		case <-waitchan:
-			repo.Close()
-		case <-sigchan:
-			log.Println("[INTERRUPT] Closing database and quitting")
-			repo.Close()
-			os.Exit(0)
-		}
-	}()
-
-	repo.NumWorkers = concurrency
-
-	if prune {
-		return repo.Prune()
-	}
-
-	return repo.Store(keepEverything)
 }
 
 func authorize() error {


### PR DESCRIPTION
This PR fixes the following issues:
* A race on shutdown when repo is closing in goroutine, but the main goroutine (and the whole program) shutdowns before the closing goroutine finishes.
* A memory leak: a new `sigchan` has been created on each `run()` and added to `signal.Notify()` without later removing.
* Remove partially downloaded files on program interruption.
* Fix a race due to which an invalid path may be written to media list file because we used the first guessed file name, but not the final one obtained from `reserveUniqueFilename()`.
* Fix a bug due to which an invalid path may be written to media list in case the file which it will points to fails to download.
* Handle SIGTERM properly (for example in case of running under systemd).