### PR TITLE
Handle HTTP errors properly

### DIFF
--- a/googlephotos/googlephotos.go
+++ b/googlephotos/googlephotos.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/mholt/photobak"
+	"errors"
 )
 
 const (
@@ -182,6 +183,10 @@ func (c *Client) DownloadItemInto(item photobak.Item, w io.Writer) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP GET %s: %s", url, resp.Status)
+	}
+
 	_, err = io.Copy(w, resp.Body)
 
 	return err
@@ -279,6 +284,10 @@ func (c *Client) getFeed(endpoint string) ([]byte, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(res.Status)
+	}
 
 	return ioutil.ReadAll(res.Body)
 }


### PR DESCRIPTION
I've got a number of strange `checksum mismatch, re-downloading` errors on my repository and decided to investigate the reason. It turned out that current implementation of `googlephotos` module doesn't check HTTP status code of HTTP response and writes body of non-`200 OK` HTTP response in place of the photo to repository (!) + there is a bug in `repo.go` due to which all download errors are ignored because invalid `err` is used.